### PR TITLE
Add daily challenge, new DJs, and refreshed tagline to Wubdle

### DIFF
--- a/public/wubdle-artists.csv
+++ b/public/wubdle-artists.csv
@@ -202,3 +202,6 @@ Ternion Sound,Trio,Male,Minnesota,Dubstep,2016,<1M
 Distinct Motive,Solo,Male,Canada,Dubstep,2013,<1M
 Liquid Stranger,Solo,Male,Sweden,Experimental Bass,2003,<1M
 Champagne Drip,Solo,Male,California,Experimental Bass,2014,<1M
+Viziion,Solo,Male,Philadelphia,Dubstep,2024,<1M
+Gran,Solo,Male,Philadelphia,Dubstep,2024,<1M
+DesRo,Solo,Male,Philadelphia,Dubstep,2024,<1M

--- a/src/Wubdle.css
+++ b/src/Wubdle.css
@@ -160,6 +160,22 @@ body.wubdle-page {
   box-shadow: 0 0 0 1px rgba(255, 90, 120, 0.7);
   color: #ffd0d0;
 }
+.wubdle-btn:disabled,
+.wubdle-btn:disabled:hover {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+.wubdle-daily-reset {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: #9b98c4;
+}
+.wubdle-daily-reset code {
+  color: var(--wubdle-cyan);
+  font-weight: 700;
+}
 
 /* ─── Toggle ─── */
 .wubdle-toggle {

--- a/src/Wubdle.css
+++ b/src/Wubdle.css
@@ -121,6 +121,7 @@ body.wubdle-page {
   border-radius: 8px;
 }
 
+.wubdle-seed-play-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .wubdle-seed-play { display: flex; gap: 6px; }
 .wubdle-seed-play input {
   width: 170px;

--- a/src/Wubdle.jsx
+++ b/src/Wubdle.jsx
@@ -11,6 +11,8 @@ const STORAGE = {
   gaveUp: 'wubdle.gaveUp',
   typeAssist: 'wubdle.typeAssist',
   seeded: 'wubdle.seeded',
+  isDaily: 'wubdle.isDaily',
+  dailyDone: 'wubdle.dailyDone',
 };
 
 const MEMBER_ORDER = ['Solo', 'Duo', 'Trio', 'Quartet', 'Quintet', 'Collective'];
@@ -49,6 +51,42 @@ function mulberry32(a) {
 
 function makeSeed() {
   return Math.random().toString(36).slice(2, 8).toUpperCase();
+}
+
+/* Today's date in US Eastern time, formatted as YYMMDD — the daily seed. */
+function getEasternDateSeed() {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: '2-digit',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date());
+  const get = (t) => parts.find((p) => p.type === t).value;
+  return `${get('year')}${get('month')}${get('day')}`;
+}
+
+/* Milliseconds until the next midnight in US Eastern time. */
+function msUntilEasternMidnight() {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(new Date());
+  const get = (t) => parseInt(parts.find((p) => p.type === t).value, 10);
+  let h = get('hour');
+  if (h === 24) h = 0;
+  const secsIntoDay = h * 3600 + get('minute') * 60 + get('second');
+  return (24 * 3600 - secsIntoDay) * 1000;
+}
+
+function formatCountdown(ms) {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = String(Math.floor(total / 3600)).padStart(2, '0');
+  const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
+  const s = String(total % 60).padStart(2, '0');
+  return `${h}:${m}:${s}`;
 }
 
 function normalize(name) {
@@ -113,6 +151,24 @@ function Wubdle() {
     return saved ? JSON.parse(saved) : false;
   });
 
+  const [isDaily, setIsDaily] = useState(() => {
+    if (initialSeed.current.fresh) return false;
+    const saved = localStorage.getItem(STORAGE.isDaily);
+    return saved ? JSON.parse(saved) : false;
+  });
+
+  const [dailyDone, setDailyDone] = useState(() => {
+    const saved = localStorage.getItem(STORAGE.dailyDone);
+    return saved ? JSON.parse(saved) : null;
+  });
+
+  /* Ticks every second so the daily reset countdown stays live. */
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
   const [input, setInput] = useState('');
   const [message, setMessage] = useState('');
   const [seedInput, setSeedInput] = useState('');
@@ -173,6 +229,19 @@ function Wubdle() {
   useEffect(() => {
     localStorage.setItem(STORAGE.typeAssist, JSON.stringify(typeAssist));
   }, [typeAssist]);
+  useEffect(() => {
+    localStorage.setItem(STORAGE.isDaily, JSON.stringify(isDaily));
+  }, [isDaily]);
+  useEffect(() => {
+    localStorage.setItem(STORAGE.dailyDone, JSON.stringify(dailyDone));
+  }, [dailyDone]);
+
+  /* Record the daily challenge as completed once it's won or given up. */
+  useEffect(() => {
+    if (isDaily && (won || gaveUp)) {
+      setDailyDone(seed);
+    }
+  }, [isDaily, won, gaveUp, seed]);
 
   /* The answer for the current seed */
   const answer = useMemo(() => {
@@ -237,10 +306,11 @@ function Wubdle() {
     submitGuess();
   }
 
-  function doNewGame(customSeed) {
+  function doNewGame(customSeed, daily = false) {
     const next = (customSeed || makeSeed()).toUpperCase();
     setSeed(next);
     setSeeded(!!customSeed);
+    setIsDaily(daily);
     setGuesses([]);
     setWon(false);
     setGaveUp(false);
@@ -262,6 +332,20 @@ function Wubdle() {
       return;
     }
     doNewGame(customSeed);
+  }
+
+  function startDaily() {
+    const dailySeed = getEasternDateSeed();
+    if (dailyDone === dailySeed) return;
+    if (guesses.length > 0 && !won && !gaveUp) {
+      requestConfirm(
+        "Start today's Daily Challenge? Your progress on the current puzzle will be lost.",
+        'Daily Challenge',
+        () => doNewGame(dailySeed, true)
+      );
+      return;
+    }
+    doNewGame(dailySeed, true);
   }
 
   function giveUp() {
@@ -312,6 +396,9 @@ function Wubdle() {
     }
   }
 
+  const todaySeed = getEasternDateSeed();
+  const dailyCompletedToday = dailyDone === todaySeed;
+
   return (
     <div className="wubdle">
       <Link to="/" className="wubdle-home-link">← Home</Link>
@@ -323,7 +410,7 @@ function Wubdle() {
           ))}
         </div>
         <h1 className="wubdle-title">WUB<span>DLE</span></h1>
-        <p className="wubdle-tagline">Match the clues. Guess the EDM artist.</p>
+        <p className="wubdle-tagline">Guess an EDM artist. Follow the clues. Find the answer.</p>
       </header>
 
       {!loaded && <p className="wubdle-loading">Loading artists…</p>}
@@ -335,7 +422,26 @@ function Wubdle() {
               <span className="wubdle-seed-label">Seed</span>
               <code className="wubdle-seed-value">{seed}</code>
               <button className="wubdle-btn ghost" onClick={() => newGame()}>New Game</button>
+              <button
+                className="wubdle-btn ghost wubdle-daily"
+                onClick={startDaily}
+                disabled={dailyCompletedToday}
+                title={
+                  dailyCompletedToday
+                    ? "You've finished today's Daily Challenge"
+                    : "Play today's Daily Challenge"
+                }
+              >
+                Daily Challenge
+              </button>
             </div>
+
+            {dailyCompletedToday && (
+              <p className="wubdle-daily-reset">
+                ✓ Daily done · next puzzle in{' '}
+                <code>{formatCountdown(msUntilEasternMidnight())}</code>
+              </p>
+            )}
 
             <form
               className="wubdle-seed-play"

--- a/src/Wubdle.jsx
+++ b/src/Wubdle.jsx
@@ -475,8 +475,12 @@ function Wubdle() {
           {won && answer && (
             <div className="wubdle-win">
               <h2>🎆 You got it!</h2>
-              {seeded && (
-                <p className="wubdle-win-badge">🌱 Seeded run · <code>{seed}</code></p>
+              {isDaily ? (
+                <p className="wubdle-win-badge">📅 Daily Challenge · <code>{seed}</code></p>
+              ) : (
+                seeded && (
+                  <p className="wubdle-win-badge">🌱 Seeded run · <code>{seed}</code></p>
+                )
               )}
               <p>
                 The artist was <strong>{answer.name}</strong>. You nailed it in{' '}

--- a/src/Wubdle.jsx
+++ b/src/Wubdle.jsx
@@ -419,8 +419,6 @@ function Wubdle() {
         <main className="wubdle-main">
           <div className="wubdle-controls">
             <div className="wubdle-seed-row">
-              <span className="wubdle-seed-label">Seed</span>
-              <code className="wubdle-seed-value">{seed}</code>
               <button className="wubdle-btn ghost" onClick={() => newGame()}>New Game</button>
               <button
                 className="wubdle-btn ghost wubdle-daily"
@@ -443,21 +441,25 @@ function Wubdle() {
               </p>
             )}
 
-            <form
-              className="wubdle-seed-play"
-              onSubmit={(e) => {
-                e.preventDefault();
-                if (seedInput.trim()) newGame(seedInput.trim());
-              }}
-            >
-              <input
-                type="text"
-                placeholder="Play a specific seed…"
-                value={seedInput}
-                onChange={(e) => setSeedInput(e.target.value)}
-              />
-              <button className="wubdle-btn" type="submit">Go</button>
-            </form>
+            <div className="wubdle-seed-play-row">
+              <span className="wubdle-seed-label">Seed</span>
+              <code className="wubdle-seed-value">{seed}</code>
+              <form
+                className="wubdle-seed-play"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  if (seedInput.trim()) newGame(seedInput.trim());
+                }}
+              >
+                <input
+                  type="text"
+                  placeholder="Play a specific seed…"
+                  value={seedInput}
+                  onChange={(e) => setSeedInput(e.target.value)}
+                />
+                <button className="wubdle-btn" type="submit">Go</button>
+              </form>
+            </div>
 
             <label className="wubdle-toggle">
               <input


### PR DESCRIPTION
## Summary

Three changes to the Wubdle EDM-artist guessing game.

### 1. New artists
Added three Philadelphia dubstep DJs to `public/wubdle-artists.csv`:

| Name | Members | Gender | Location | Subgenre | First Record | Monthly Spotify |
|------|---------|--------|----------|----------|--------------|-----------------|
| Viziion | Solo | Male | Philadelphia | Dubstep | 2024 | <1M |
| Gran | Solo | Male | Philadelphia | Dubstep | 2024 | <1M |
| DesRo | Solo | Male | Philadelphia | Dubstep | 2024 | <1M |

### 2. Daily Challenge
- New **Daily Challenge** button placed between **New Game** and **Give up**.
- The seed is the current date in US Eastern time (`America/New_York`) formatted as `YYMMDD`, so everyone gets the same puzzle each day.
- Once the daily puzzle is completed (won or given up), the button grays out and a live countdown shows the time until the puzzle resets at midnight ET.
- Daily completion is persisted to `localStorage` (keyed by the day's seed), so it survives refreshes and automatically re-enables after midnight ET.

### 3. Tagline
Changed from "Match the clues. Guess the EDM artist." to **"Guess an EDM artist. Follow the clues. Find the answer."**

## Testing
- `npm run build` succeeds.
- Verified the ET seed/countdown helpers produce correct `YYMMDD` values.