### PR TITLE
Improve Wubdle controls and board layout on mobile

### DIFF
--- a/src/Wubdle.css
+++ b/src/Wubdle.css
@@ -430,6 +430,32 @@ body.wubdle-page {
 }
 
 @media (max-width: 600px) {
-  .wubdle-controls { gap: 10px; }
-  .wubdle-seed-play input { width: 130px; }
+  .wubdle-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+    padding: 14px;
+  }
+  .wubdle-seed-row,
+  .wubdle-seed-play-row {
+    width: 100%;
+    justify-content: center;
+  }
+  .wubdle-seed-row .wubdle-btn { flex: 1 1 0; min-width: 0; }
+  .wubdle-seed-play { flex: 1 1 160px; }
+  .wubdle-seed-play input { flex: 1; width: auto; min-width: 0; }
+  .wubdle-daily-reset { text-align: center; margin: 0; }
+  .wubdle-toggle { justify-content: center; }
+
+  .wubdle-input-wrap { flex-wrap: wrap; }
+  .wubdle-input-wrap > input { flex: 1 1 100%; }
+  .wubdle-input-wrap > .wubdle-btn { flex: 1 1 0; }
+
+  .wubdle-win-actions,
+  .wubdle-giveup .wubdle-win-actions,
+  .wubdle-modal-actions { flex-wrap: wrap; }
+
+  .wubdle-row { gap: 3px; }
+  .wubdle-cell { padding: 8px 2px; }
+  .wubdle-name-cell { padding-left: 6px; }
 }


### PR DESCRIPTION
Stack the control groups vertically and let the seed input, buttons, and guess form flex to fill their rows on narrow screens. Allow the guess form and action button rows to wrap, and tighten board cell spacing so the 8-column grid stays readable on small screens.